### PR TITLE
Patch for dispatching multiple actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consus-flux",
   "description": "Flux modules for the Consus project",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "The Four Fiths",
   "contributors": [
     "Jordan Longato",

--- a/src/lib/dispatcher.js
+++ b/src/lib/dispatcher.js
@@ -57,6 +57,7 @@ class Dispatcher {
      * Pass an action to the dispatcher which will be sent to listeners
      */
     handleAction(action) {
+        this.calledListeners = Object.create(null);
         this.currentAction = action;
         Object.keys(this.listeners).forEach(dispatchToken => this.callListener(dispatchToken));
     }

--- a/test/unit/lib/dispatcher.js
+++ b/test/unit/lib/dispatcher.js
@@ -72,7 +72,7 @@ describe('Dispatcher', () => {
 
     describe('#handleAction', () => {
 
-        it('should handle an action', () => {
+        it('should handle actions', () => {
             let spyA = sinon.spy();
             let spyB = sinon.spy();
             Dispatcher.register(spyA);
@@ -80,6 +80,9 @@ describe('Dispatcher', () => {
             Dispatcher.handleAction({});
             assert.isTrue(spyA.calledOnce);
             assert.isTrue(spyB.calledOnce);
+            Dispatcher.handleAction({});
+            assert.isTrue(spyA.calledTwice);
+            assert.isTrue(spyB.calledTwice);
         });
 
     });


### PR DESCRIPTION
The `calledListeners` attribute was not being cleared out for new actions, so each listener could only receive up to one action. This patch fixes that issue.
