### PR TITLE
Switch from JSHint to ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,6 @@
             2,
             "single"
         ],
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
         "semi": [
             2,
             "always"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+    "rules": {
+        "indent": [
+            2,
+            4
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ]
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "sourceType": "module"
+    },
+    "env": {
+        "es6": true,
+        "mocha": true,
+        "node": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,0 @@
-{
-    "node": true,
-    "esnext": true
-}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,14 +25,11 @@ module.exports = function(grunt) {
                 ]
             }
         },
-        jshint: {
+        eslint: {
             options: {
-                jshintrc: '.jshintrc'
+                configFile: '.eslintrc.json'
             },
-            uses_defaults: [
-                'src/**/*.js',
-                'test/**/*.js'
-            ]
+            src: ['src/**/*.js', 'test/**/*.js']
         },
         mochacli: {
             options: {
@@ -51,12 +48,12 @@ module.exports = function(grunt) {
     });
 
     grunt.loadNpmTasks('grunt-babel');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-eslint');
     grunt.loadNpmTasks('grunt-mocha-cli');
     grunt.loadNpmTasks('grunt-contrib-clean');
 
     grunt.registerTask('build', ['clean:dist', 'babel:dist']);
-    grunt.registerTask('lint', ['jshint']);
+    grunt.registerTask('lint', ['eslint']);
     grunt.registerTask('test', ['lint', 'build', 'clean:test', 'babel:test', 'mochacli']);
     grunt.registerTask('prepublish', ['test', 'clean:dist', 'babel:dist']);
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "the four fifths"
   ],
   "devDependencies": {
+    "babel-eslint": "^7.0.0",
     "babel-plugin-istanbul": "^2.0.1",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
@@ -42,7 +43,7 @@
     "grunt-babel": "^6.0.0",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-mocha-cli": "^2.1.0",
     "nyc": "^8.3.0",
     "sinon": "^1.17.6"

--- a/test/unit/lib/dispatcher.js
+++ b/test/unit/lib/dispatcher.js
@@ -52,8 +52,7 @@ describe('Dispatcher', () => {
             let spyA = sinon.spy();
             let spyB = sinon.spy();
             let tokenA = Dispatcher.register(spyA);
-            /* eslint-disable no-unused-vars */
-            let tokenB = Dispatcher.register(spyB);
+            Dispatcher.register(spyB);
             Dispatcher.currentAction = {};
             Dispatcher.waitFor(tokenA);
             assert.isTrue(spyA.calledOnce);

--- a/test/unit/lib/dispatcher.js
+++ b/test/unit/lib/dispatcher.js
@@ -52,6 +52,7 @@ describe('Dispatcher', () => {
             let spyA = sinon.spy();
             let spyB = sinon.spy();
             let tokenA = Dispatcher.register(spyA);
+            /* eslint-disable no-unused-vars */
             let tokenB = Dispatcher.register(spyB);
             Dispatcher.currentAction = {};
             Dispatcher.waitFor(tokenA);


### PR DESCRIPTION
### Summary

We're switching to ESLint because TheFourFifths/consus-client will be using React/JSX, and JSHint does not support that. To make things simpler, we'll use the same linter (ESLint) across all projects.
### Checklist
- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: YES :white_check_mark:
### How to Review
1. Verify that ESLint is being used by looking in `package.json`/`Gruntfile.js`
2. Run `grunt lint`
### Links
- [TFF-51](https://msoese.atlassian.net/browse/TFF-51)
