### PR TITLE
Change the signature of handleAction

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,11 @@ module.exports = function(grunt) {
                 files: {
                     src: ['.test/unit/**/*.js']
                 }
+            },
+            functional: {
+                files: {
+                    src: ['.test/functional/**/*.js']
+                }
             }
         },
         clean: {

--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ Flux modules for the Consus project
 ```javascript
 import { Dispatcher } from 'consus-flux';
 
-Dispatcher.handleAction({
-    type: 'INCREMENT',
-    data: {
-        amount: 5
-    }
+Dispatcher.handleAction('INCREMENT', {
+    amount: 5
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consus-flux",
   "description": "Flux modules for the Consus project",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "The Four Fiths",
   "contributors": [
     "Jordan Longato",

--- a/src/lib/dispatcher.js
+++ b/src/lib/dispatcher.js
@@ -56,9 +56,12 @@ class Dispatcher {
     /**
      * Pass an action to the dispatcher which will be sent to listeners
      */
-    handleAction(action) {
+    handleAction(type, data) {
         this.calledListeners = Object.create(null);
-        this.currentAction = action;
+        this.currentAction = {
+            type,
+            data
+        };
         Object.keys(this.listeners).forEach(dispatchToken => this.callListener(dispatchToken));
     }
 

--- a/test/functional/counter-store.js
+++ b/test/functional/counter-store.js
@@ -1,0 +1,38 @@
+import { Store } from '../../.dist/index';
+
+let count = 0;
+
+class CounterStore extends Store {
+
+    getCount() {
+        return count;
+    }
+
+}
+
+const store = new CounterStore();
+
+store.registerHandler('RESET', () => {
+    count = 0;
+    store.emitChange();
+});
+
+store.registerHandler('INCREMENT', data => {
+    if (typeof data === 'object') {
+        count += data.amount;
+    } else {
+        count += 1;
+    }
+    store.emitChange();
+});
+
+store.registerHandler('DECREMENT', data => {
+    if (typeof data === 'object') {
+        count -= data.amount;
+    } else {
+        count -= 1;
+    }
+    store.emitChange();
+});
+
+export default store;

--- a/test/functional/counter-test.js
+++ b/test/functional/counter-test.js
@@ -1,0 +1,63 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { Dispatcher } from '../../.dist/index';
+import CounterStore from './counter-store';
+
+describe('Counter', () => {
+
+    let spyA = sinon.spy();
+    let spyB = sinon.spy();
+
+    it('should start at 0', () => {
+        assert.strictEqual(CounterStore.getCount(), 0);
+    });
+
+    it('should add change listeners', () => {
+        CounterStore.addChangeListener(spyA);
+        CounterStore.addChangeListener(spyB);
+    });
+
+    it('should increment the default amount', () => {
+        Dispatcher.handleAction('INCREMENT');
+        assert.strictEqual(CounterStore.getCount(), 1);
+        assert.strictEqual(spyA.callCount, 1);
+        assert.strictEqual(spyB.callCount, 1);
+    });
+
+    it('should increment by a given amount', () => {
+        Dispatcher.handleAction('INCREMENT', {
+            amount: 5
+        });
+        assert.strictEqual(CounterStore.getCount(), 6);
+        assert.strictEqual(spyA.callCount, 2);
+        assert.strictEqual(spyB.callCount, 2);
+    });
+
+    it('should decrement by the default amount', () => {
+        Dispatcher.handleAction('DECREMENT');
+        assert.strictEqual(CounterStore.getCount(), 5);
+        assert.strictEqual(spyA.callCount, 3);
+        assert.strictEqual(spyB.callCount, 3);
+    });
+
+    it('should decrement by a given amount', () => {
+        Dispatcher.handleAction('DECREMENT', {
+            amount: 3
+        });
+        assert.strictEqual(CounterStore.getCount(), 2);
+        assert.strictEqual(spyA.callCount, 4);
+        assert.strictEqual(spyB.callCount, 4);
+    });
+
+    it('should remove a change listener', () => {
+        CounterStore.removeChangeListener(spyB);
+    });
+
+    it('should reset the counter', () => {
+        Dispatcher.handleAction('RESET');
+        assert.strictEqual(CounterStore.getCount(), 0);
+        assert.strictEqual(spyA.callCount, 5);
+        assert.strictEqual(spyB.callCount, 4);
+    });
+
+});

--- a/test/unit/lib/dispatcher.js
+++ b/test/unit/lib/dispatcher.js
@@ -77,7 +77,7 @@ describe('Dispatcher', () => {
             let spyB = sinon.spy();
             Dispatcher.register(spyA);
             Dispatcher.register(spyB);
-            Dispatcher.handleAction({});
+            Dispatcher.handleAction();
             assert.isTrue(spyA.calledOnce);
             assert.isTrue(spyB.calledOnce);
             Dispatcher.handleAction({});

--- a/test/unit/lib/dispatcher.js
+++ b/test/unit/lib/dispatcher.js
@@ -80,7 +80,7 @@ describe('Dispatcher', () => {
             Dispatcher.handleAction();
             assert.isTrue(spyA.calledOnce);
             assert.isTrue(spyB.calledOnce);
-            Dispatcher.handleAction({});
+            Dispatcher.handleAction();
             assert.isTrue(spyA.calledTwice);
             assert.isTrue(spyB.calledTwice);
         });


### PR DESCRIPTION
### Summary

This changes the signature of the Dispatcher's `handleAction` method to accept the `type` and `data` as two separate parameters, rather than as values of a single parameter object.
### Checklist
- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :white_check_mark:
### How to Review
1. Read the changed `Dispatcher.js` file to verify the changed parameters.
2. Check the `README.md` for an updated example.
3. Verify that the new and old tests all pass.
### Links

Put links to Jira tickets, and anything else, here.
- https://eecstsc.slack.com/archives/general/p1475955414000379

![image](https://cloud.githubusercontent.com/assets/5055041/19216075/028de932-8d75-11e6-892d-429f4982f14d.png)
