### PR TITLE
Add an npm version badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/TheFourFifths/consus-flux.svg?branch=dev)](https://travis-ci.org/TheFourFifths/consus-flux)
 [![codecov](https://codecov.io/gh/TheFourFifths/consus-flux/branch/dev/graph/badge.svg)](https://codecov.io/gh/TheFourFifths/consus-flux)
+[![npm](https://img.shields.io/npm/v/consus-flux.svg)](https://www.npmjs.com/package/consus-flux)
 [![devDependency Status](https://david-dm.org/TheFourFifths/consus-flux/dev-status.svg)](https://david-dm.org/TheFourFifths/consus-flux?type=dev)
 
 Flux modules for the Consus project


### PR DESCRIPTION
### Summary

This adds a version badge for the npm release.
### Checklist
- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :white_check_mark:
### How to Review
1. Look at the [new badge in the README](https://github.com/TheFourFifths/consus-flux/tree/npm-version-badge#consus-flux).
2. Contain your excitement.
3. Verify that clicking the badge takes you to the npm page for this module.
4. Verify that the latest version is shown by the badge.
### Links
- https://github.com/TheFourFifths/consus-flux/tree/npm-version-badge#consus-flux
- https://www.npmjs.com/package/consus-flux
