### PR TITLE
:memo: Fix typo in example listening to Store

### DIFF
--- a/docs/flux.md
+++ b/docs/flux.md
@@ -51,7 +51,7 @@ function handleChange() {
 
 CounterStore.addChangeListener(handleChange);
 
-setTimeout(() {
+setTimeout(() => {
     CounterStore.removeChangeListener(handleChange);
 }, 10000);
 ```


### PR DESCRIPTION
### Summary

Fix a typo in the documentation example for listening to a Store.

### Checklist

- [ ] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :white_check_mark:

### How to Review

1. Read it
