### PR TITLE
Hotfix/coverage report

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,4 +1,5 @@
 {
+    "all": true,
     "include": [
         "src/**/*.js"
     ],

--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,6 @@
 {
     "all": true,
+    "cache": true,
     "include": [
         "src/**/*.js"
     ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ install:
   - npm install
 
 script:
-  - npm test
+  - npm run coverage
 
 after_success:
-  - npm run coverage
   - bash <(curl -s https://codecov.io/bash)
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - 'node' # ensure we're always testing on the latest version of Node.js
   - '6'
   - '4'
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,10 @@ coverage:
       default:
         url: secret:zAChUP65Q3h28t2CYkf2vhL+54O0I8A9SMmSPmc3FiecRJdoOv2ekTUMh+mYW3FY6pJnXXGEqjPlhBe2Oj78CyPO6V3yBqToOP8Y0inPgKTMZzfFlX+UYWZoNJEtMD0hrmoUnVpZr/VIpPh0n2dgHrjVPHaChz8VmBWFdlXyBUY=
         attachments: "diff, sunburst"
+  status:
+    project:
+      default:
+        target: auto
 
 fixes:
   - ".dist/::src/"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-plugin-istanbul": "^2.0.1",
+    "babel-plugin-istanbul": "^3.0.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
     "chai": "^3.5.0",
@@ -45,7 +45,7 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-eslint": "^19.0.0",
     "grunt-mocha-cli": "^2.1.0",
-    "nyc": "^8.3.0",
+    "nyc": "^9.0.1",
     "sinon": "^1.17.6"
   },
   "dependencies": {


### PR DESCRIPTION
### Summary

- Enable coverage reporting for _all_ files, even the ones that don't have tests
- Hopefully speed-up Travis CI test speed by:
  - caching instrumented source
  - only running the test suite once by running `npm run coverage` in the `script` stage (coverage is only computed, not checked)

**Ignore the decreased coverage reported by codecov for this PR.**

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: :white_check_mark: 

### How to Review

- Read the diff
- Witness the decrease in code coverage

### Links

- [`babel-plugin-istanbul` changelog](https://github.com/istanbuljs/babel-plugin-istanbul/compare/v2.0.1...v3.0.0)
- [codecov.io commit status docs](http://docs.codecov.io/docs/commit-status)
- [`nyc` changelog](https://github.com/istanbuljs/nyc/compare/v8.3.0...v9.0.1)
