### PR TITLE
Clone Submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Common modules for the Consus project
 
 `npm install consus-core --save`
 
+## Submodules
+
+* [Clone](docs/clone.md)
+* [Flux](docs/flux.md)
+* [Identifiers](docs/identifiers.md)
+
 ## Developing
 
 ### Getting Started

--- a/clone.js
+++ b/clone.js
@@ -1,0 +1,1 @@
+module.exports = require('./.dist/clone/index');

--- a/docs/clone.md
+++ b/docs/clone.md
@@ -1,0 +1,30 @@
+# Clone
+
+## Using `clone`
+
+```javascript
+import clone from 'consus-core/clone';
+
+let original = {
+    a: [0, 1, 2],
+    b: 'Hello, World!',
+    c: 3.14159265
+};
+
+let twin = clone(original);
+
+twin;
+/*
+{
+    a: [0, 1, 2],
+    b: 'Hello, World!',
+    c: 3.14159265
+}
+*/
+
+twin == original;
+// false
+
+twin.a == original.a;
+// false
+```

--- a/docs/clone.md
+++ b/docs/clone.md
@@ -22,9 +22,9 @@ twin;
 }
 */
 
-twin == original;
+twin === original;
 // false
 
-twin.a == original.a;
+twin.a === original.a;
 // false
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+    clone: require('./clone'),
     flux: require('./flux'),
     identifiers: require('./identifiers')
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consus-core",
   "description": "Common modules for the Consus project",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "author": "The Four Fifths",
   "contributors": [
     "Jordan Longato",

--- a/src/clone/index.js
+++ b/src/clone/index.js
@@ -18,7 +18,7 @@ export default function clone(original) {
     case 'function':
         return cloneFunction(original);
     default:
-        throw new Error('Unkown type: ' + typeof original);
+        throw new Error(`Unkown type:  ${typeof original}`);
     }
 }
 

--- a/src/clone/index.js
+++ b/src/clone/index.js
@@ -1,0 +1,51 @@
+const PRIMITIVE_TYPES = [
+    'undefined',
+    'boolean',
+    'number',
+    'string',
+    'symbol'
+];
+
+export default function clone(original) {
+    // Check for immutable primitives
+    if (original === null || PRIMITIVE_TYPES.indexOf(typeof original) > -1) {
+        return original;
+    }
+    // Handle mutable types
+    switch (typeof original) {
+    case 'object':
+        return cloneObject(original);
+    case 'function':
+        return cloneFunction(original);
+    default:
+        throw new Error('Unkown type: ' + typeof original);
+    }
+}
+
+function cloneObject(original) {
+    // Check for arrays
+    if (Array.isArray(original)) {
+        return cloneArray(original);
+    }
+    // Create a completely empty object
+    let twin = Object.create(null);
+    // Clone all attributes
+    Object.keys(original).forEach(key => twin[key] = clone(original[key]));
+    return twin;
+}
+
+function cloneArray(original) {
+    // Create an empty array
+    let twin = [];
+    // Clone all elements/attributes
+    Object.keys(original).forEach(key => twin[key] = clone(original[key]));
+    return twin;
+}
+
+function cloneFunction(original) {
+    // Convert the base function to a string, and create a new function from this
+    let twin = new Function(`return ${original.toString()};`)();
+    // Clone all attributes
+    Object.keys(original).forEach(key => twin[key] = clone(original[key]));
+    return twin;
+}

--- a/test/clone/unit/index.js
+++ b/test/clone/unit/index.js
@@ -42,7 +42,7 @@ describe('Clone', () => {
         }
         original.a = 3;
         let twin = clone(original);
-        assert.notEqual(twin, original);
+        assert.notStrictEqual(twin, original);
         assert.strictEqual(twin.toString(), original.toString());
         assert.strictEqual(twin.name, original.name);
         assert.strictEqual(twin.a, 3);
@@ -55,7 +55,7 @@ describe('Clone', () => {
             15
         ];
         let twin = clone(original);
-        assert.notEqual(twin, original);
+        assert.notStrictEqual(twin, original);
         assert.deepEqual(twin, original);
     });
 
@@ -66,7 +66,7 @@ describe('Clone', () => {
             c: 7
         };
         let twin = clone(original);
-        assert.notEqual(twin, original);
+        assert.notStrictEqual(twin, original);
         assert.deepEqual(twin, original);
     });
 
@@ -95,10 +95,10 @@ describe('Clone', () => {
             }
         ];
         let twin = clone(original);
-        assert.notEqual(twin, original);
-        assert.notEqual(twin[6], original[6]);
-        assert.notEqual(twin[6][2], original[6][2]);
-        assert.notEqual(twin[7], original[7]);
+        assert.notStrictEqual(twin, original);
+        assert.notStrictEqual(twin[6], original[6]);
+        assert.notStrictEqual(twin[6][2], original[6][2]);
+        assert.notStrictEqual(twin[7], original[7]);
         assert.deepEqual(twin, original);
     });
 
@@ -127,10 +127,10 @@ describe('Clone', () => {
             }
         };
         let twin = clone(original);
-        assert.notEqual(twin, original);
-        assert.notEqual(twin.g, original.g);
-        assert.notEqual(twin.g[2], original.g[2]);
-        assert.notEqual(twin.h, original.h);
+        assert.notStrictEqual(twin, original);
+        assert.notStrictEqual(twin.g, original.g);
+        assert.notStrictEqual(twin.g[2], original.g[2]);
+        assert.notStrictEqual(twin.h, original.h);
         assert.deepEqual(twin, original);
     });
 

--- a/test/clone/unit/index.js
+++ b/test/clone/unit/index.js
@@ -1,0 +1,137 @@
+import { assert } from 'chai';
+import clone from '../../../clone';
+
+describe('Clone', () => {
+
+    it('should handle null', () => {
+        assert.isNull(clone(null));
+    });
+
+    it('should handle undefined', () => {
+        assert.isUndefined(clone(undefined));
+    });
+
+    it('should handle booleans', () => {
+        assert.isFalse(clone(false));
+        assert.isTrue(clone(true));
+    });
+
+    it('should handle numbers', () => {
+        assert.strictEqual(clone(42), 42);
+        assert.strictEqual(clone(3.14159265358979), 3.14159265358979);
+        assert.strictEqual(clone(0), 0);
+        assert.strictEqual(clone(-1.6180339887), -1.6180339887);
+        assert.strictEqual(clone(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY);
+        assert.strictEqual(clone(Number.NEGATIVE_INFINITY), Number.NEGATIVE_INFINITY);
+    });
+
+    it('should handle strings', () => {
+        assert.strictEqual(clone('Hello, World!'), 'Hello, World!');
+        assert.strictEqual(clone('abc123'), 'abc123');
+        assert.strictEqual(clone('Consus'), 'Consus');
+    });
+
+    it('should handle symbols', () => {
+        let symbol = Symbol();
+        assert.strictEqual(clone(symbol), symbol);
+    });
+
+    it('should handle functions', () => {
+        function original(x, y) {
+            return x + y;
+        }
+        original.a = 3;
+        let twin = clone(original);
+        assert.notEqual(twin, original);
+        assert.strictEqual(twin.toString(), original.toString());
+        assert.strictEqual(twin.name, original.name);
+        assert.strictEqual(twin.a, 3);
+    });
+
+    it('should handle arrays', () => {
+        let original = [
+            3,
+            10,
+            15
+        ];
+        let twin = clone(original);
+        assert.notEqual(twin, original);
+        assert.deepEqual(twin, original);
+    });
+
+    it('should handle objects', () => {
+        let original = {
+            a: 3,
+            b: 5,
+            c: 7
+        };
+        let twin = clone(original);
+        assert.notEqual(twin, original);
+        assert.deepEqual(twin, original);
+    });
+
+    it('should handle deep arrays', () => {
+        let symbol = Symbol();
+        let original = [
+            null,
+            undefined,
+            false,
+            42,
+            'Hello, World!',
+            symbol,
+            [
+                3,
+                10,
+                [
+                    9,
+                    1,
+                    4
+                ]
+            ],
+            {
+                a: 2,
+                b: 5,
+                c: 7
+            }
+        ];
+        let twin = clone(original);
+        assert.notEqual(twin, original);
+        assert.notEqual(twin[6], original[6]);
+        assert.notEqual(twin[6][2], original[6][2]);
+        assert.notEqual(twin[7], original[7]);
+        assert.deepEqual(twin, original);
+    });
+
+    it('should handle deep objects', () => {
+        let symbol = Symbol();
+        let original = {
+            a: null,
+            b: undefined,
+            c: false,
+            d: 42,
+            e: 'Hello, World!',
+            f: symbol,
+            g: [
+                3,
+                10,
+                [
+                    9,
+                    1,
+                    4
+                ]
+            ],
+            h: {
+                a: 2,
+                b: 5,
+                c: 7
+            }
+        };
+        let twin = clone(original);
+        assert.notEqual(twin, original);
+        assert.notEqual(twin.g, original.g);
+        assert.notEqual(twin.g[2], original.g[2]);
+        assert.notEqual(twin.h, original.h);
+        assert.deepEqual(twin, original);
+    });
+
+});


### PR DESCRIPTION
### Summary

Adds a `clone` submodule for deep cloning variables and bumps the minor version to 0.6.0. This will be useful for returning mutation-safe values from stores without explicitly creating new objects. For example:

```javascript
class StudentStore extends Store {
    getStudent(id) {
        return clone(students[id]);
    }
}
```

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :palm_tree:

### How to Review

1. Review the code diff, particularly [`src/clone/index.js`](https://github.com/TheFourFifths/consus-core/blob/hotfix-clone/src/clone/index.js).
2. Examine the [new Submodules section](https://github.com/TheFourFifths/consus-core/tree/hotfix-clone#submodules) of the README.
3. Read the [Clone documentation](https://github.com/TheFourFifths/consus-core/blob/hotfix-clone/docs/clone.md) for clarity.
4. Review the [new tests](https://github.com/TheFourFifths/consus-core/blob/hotfix-clone/test/clone/unit/index.js) for thoroughness and verify that they are all passing.

### Links

*none*
